### PR TITLE
Allow to use AvaTax SDK on jre < 1.8

### DIFF
--- a/src/main/java/net/avalara/avatax/rest/client/AvaTaxClient.java
+++ b/src/main/java/net/avalara/avatax/rest/client/AvaTaxClient.java
@@ -1,17 +1,16 @@
 package net.avalara.avatax.rest.client;
 
 import com.google.gson.reflect.TypeToken;
-import net.avalara.avatax.rest.client.models.*;
 import net.avalara.avatax.rest.client.enums.*;
+import net.avalara.avatax.rest.client.models.*;
+import org.apache.commons.codec.binary.Base64;
 
 import java.math.BigDecimal;
-import java.util.Base64;
+import java.util.ArrayList;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.ArrayList;
 
 public class AvaTaxClient {
 
@@ -59,7 +58,7 @@ public class AvaTaxClient {
         String header = null;
 
         try {
-            header = Base64.getEncoder().encodeToString((username + ":" + password).getBytes("utf-8"));
+            header = Base64.encodeBase64String((username + ":" + password).getBytes("utf-8"));
         } catch (java.io.UnsupportedEncodingException ex) {
             System.out.println("Could not find encoding for UTF-8.");
             ex.printStackTrace();


### PR DESCRIPTION
Hi, we have to use java7 in our production environment and going to integrate with AvaTax, but it's impossible because there is some class from jdk8 used in code.

I've changed dependency from java.util.Base64 to org.apache.commons.codec.binary.Base64 from commons-codec which comes along with apache http-client library. 