### PR TITLE
upgrade sbt and dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ organization := "net.avalara.avatax"
 
 version := "19.12.1"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.12"
 
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
@@ -21,12 +21,14 @@ publishTo := {
   if (isSnapshot.value)
     Some("snapshots" at nexus + "content/repositories/snapshots")
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
+    Some("releases" at nexus + "service/local/staging/deploy/maven2")
 }
 
 publishArtifact in Test := false
 
-pomIncludeRepository := { _ => false }
+pomIncludeRepository := { _ =>
+  false
+}
 
 pomExtra := (
   <url>https://github.com/avadev/AvaTax-REST-V2-JRE-SDK</url>
@@ -52,19 +54,22 @@ pomExtra := (
 libraryDependencies ++= Seq(
   // Uncomment to use Akka
   //"com.typesafe.akka" % "akka-actor_2.11" % "2.3.9",
-  "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-  "com.google.code.gson" % "gson" % "2.8.2",
-  "org.apache.httpcomponents" % "httpclient" % "4.5.2"
+  "org.scalatest" %% "scalatest" % "3.0.8" % "test",
+  "com.google.code.gson" % "gson" % "2.8.6",
+  "org.apache.httpcomponents" % "httpclient" % "4.5.11"
 )
 
-//lazy val downloadSwaggerAndGenerateClient = taskKey[Unit]("Generating client from latest swagger.json")
+// lazy val downloadSwaggerAndGenerateClient = taskKey[Unit]("Generating client from latest swagger.json")
 
-//downloadSwaggerAndGenerateClient := {
-//  val swaggerDoc = new File("./project/swagger.json")
-//  IO.download(new URL("https://sandbox-rest.avatax.com/swagger/v2/swagger.json"), swaggerDoc)
-//  val model = ParseSwagger.parseSwaggerDocument(IO.read(swaggerDoc))
-//
-//  ClientGenerator.renderClient(model)
-//}
+// downloadSwaggerAndGenerateClient := {
+//   val swaggerDoc = new File("./project/swagger.json")
+//   val url = new URL("https://sandbox-rest.avatax.com/swagger/v2/swagger.json")
+//   val json = sbt.io.Using.urlInputStream(url) { in =>
+//     IO.transfer(in, swaggerDoc); IO.read(swaggerDoc)
+//   }
+//   val model = ParseSwagger.parseSwaggerDocument(json)
 
-compile in Compile <<= (compile in Compile) //.dependsOn(downloadSwaggerAndGenerateClient)
+//   ClientGenerator.renderClient(model)
+// }
+
+// Compile / compile := (Compile / compile).dependsOn(downloadSwaggerAndGenerateClient).value

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,4 +1,4 @@
 #Activator-generated Properties
 #Wed Nov 23 12:07:44 PST 2016
 template.uuid=9cbaa284-7f8c-4ef2-b48e-fc3ee73a11eb
-sbt.version=0.13.8
+sbt.version=1.3.7

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -2,11 +2,8 @@ name := """avatax-rest-v2-api-java-build"""
 
 version := "1.0"
 
-scalaVersion := "2.10.6"
-
 libraryDependencies ++= Seq(
   // Uncomment to use Akka
   //"com.typesafe.akka" % "akka-actor_2.11" % "2.3.9",
-  "com.typesafe.play" %% "play-json" % "2.4.8"
+  "com.typesafe.play" %% "play-json" % "2.6.14"
 )
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "0.8")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")


### PR DESCRIPTION
sbt 0.13.x -> 1.3.7
sbt syntax fixes

CodeGenerator / Swagger
project/scala 2.10.x -> 2.11

fix code generation issues:

make basePath optional (due to it not existing in
https://sandbox-rest.avatax.com/swagger/v2/swagger.json)

fix parse error for SwaggerProperty.default
required String type fail parsing for the above json
that contained strings, integers and booleans in the json payload

all of the above are now supported and converted to string
representation

upgrade dependencies to latest version compatible with 2.11, 2.12, 2.13

running the `sbt downloadSwaggerAndGenerateClient`
works but the generated code doesn't compile,
most likely to the swagger.json