### PR TITLE
Do not override entire user config by setting a timeout

### DIFF
--- a/src/main/java/net/avalara/avatax/rest/client/RestCall.java
+++ b/src/main/java/net/avalara/avatax/rest/client/RestCall.java
@@ -112,11 +112,57 @@ public class RestCall<T> implements Callable<T> {
     }
 
     private void buildRequest(HttpRequestBase baseRequest) {
+        addTimeOutIfRequired(baseRequest);
 
-        int timeOut = 1200000;
-        RequestConfig requestConfig = RequestConfig.custom().setSocketTimeout(timeOut).setConnectTimeout(timeOut).setConnectionRequestTimeout(timeOut).build();
-        baseRequest.setConfig(requestConfig);
         String clientId = String.format("%s; %s; %s; %s; %s", appName, appVersion, "JavaRestClient", "20.7.0", machineName);
         baseRequest.setHeader(AvaTaxConstants.XClientHeader, clientId);
+    }
+
+    private void addTimeOutIfRequired( HttpRequestBase baseRequest ) {
+        RequestConfig userConfig = getUserConfig();
+        if (isTimeOutMissing(userConfig)) {
+            addTimeOut(baseRequest, userConfig);
+        }
+    }
+
+    private boolean isTimeOutMissing( RequestConfig userConfig ) {
+        if (userConfig == null) {
+            return true;
+        }
+
+        // Only override user config if user did not explicitly set a timeout
+        return userConfig.getConnectionRequestTimeout() == -1 || userConfig.getConnectTimeout() == -1 || userConfig.getSocketTimeout() == -1;
+    }
+
+    private void addTimeOut( HttpRequestBase baseRequest, RequestConfig userConfig ) {
+        int timeOut = 120_000;
+
+        RequestConfig.Builder builder;
+        if (userConfig != null) {
+            builder = RequestConfig.copy(userConfig);
+            if (userConfig.getConnectionRequestTimeout() == -1) {
+                builder.setConnectionRequestTimeout(timeOut);
+            }
+            if (userConfig.getConnectTimeout() == -1) {
+                builder.setConnectTimeout(timeOut);
+            }
+            if (userConfig.getSocketTimeout() == -1) {
+                builder.setSocketTimeout(timeOut);
+            }
+        } else {
+            builder = RequestConfig.custom().setSocketTimeout(timeOut).setConnectTimeout(timeOut).setConnectionRequestTimeout(timeOut);
+        }
+
+        RequestConfig requestConfig = builder.build();
+        baseRequest.setConfig(requestConfig);
+    }
+
+    private RequestConfig getUserConfig() {
+        if (client instanceof Configurable) {
+            Configurable configurable = (Configurable)client;
+            return configurable.getConfig();
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Since [this commit](https://github.com/avadev/AvaTax-REST-V2-JRE-SDK/commit/e9068c53ed5bea12b79fa7e577e5d069d8b0ed58) user provided `RequestConfig` is always overridden by the timeout that is set by `buildRequest`.

For our current integration, this means that we are unable to specify custom timeouts.

This PR fixed the issue by only overriding those timeouts the user of the library did not explicitly set.

Also, when setting the timeouts, a copy of the user's config is made so that user's changes are not overriden.

Currently this issue prevents us from using the latest version. We use 20.1.1, the latest version that allows custom user timeouts.