### PR TITLE
AS-142: Logging changes for V2 JRE SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,3 +76,35 @@ have been changed to
 	downloadTaxRatesByZipCodeAsync(String date, String region)
 	downloadTaxRatesByZipCodeAsync(String date, String region)
 ```
+
+# How to enable logging in SDK
+* SLF4J The Simple Logging Facade for Java (SLF4J) serves as a simple facade or abstraction for various logging frameworks.
+* Client would need to implement the slf4j provider (or binding) on their end like Log4J, Logback etc to enable logging.
+* By default there is no logging enabled.
+* All the attributes which are part of log message are in **LogObject.java**
+* To enable or disable logging of request and response object, there is a boolean variable **shouldLogRequestAndResponse** in AvataxConstants. Default is set to **FALSE**
+* Output of logging is in **JSON** format.
+
+Following example shows how logging could be enabled on client side using Log4J.
+* In build.sbt or pom.xml we would add the following changes:
+```java
+// build.sbt
+"org.slf4j" % "slf4j-log4j12" % "2.0.1"
+
+//pom.xml
+<dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>slf4j-log4j12</artifactId>
+    <version>2.0.1</version>
+</dependency>
+```
+* Make sure to refresh the project to get the latest dependencies
+* Under src - > main - > resources folder create log4j.properties file and add the configurations which would cater your needs. One such example is below
+```java
+log4j.rootLogger=INFO, STDOUT
+log4j.appender.STDOUT=org.apache.log4j.ConsoleAppender
+log4j.appender.STDOUT.layout=org.apache.log4j.PatternLayout
+log4j.appender.STDOUT.layout.ConversionPattern=%5p [%t] (%F:%L) - %m%n
+```
+Please note that log4j.properties(or any other configuration) file could contain a variety of configurations such as adding logs to a log file, how to construct the log file name etc.
+Current example only shows the configuration to display logs at console only.

--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,8 @@ libraryDependencies ++= Seq(
   //"com.typesafe.akka" % "akka-actor_2.11" % "2.3.9",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "com.google.code.gson" % "gson" % "2.9.0",
-  "org.apache.httpcomponents" % "httpclient" % "4.5.13"
+  "org.apache.httpcomponents" % "httpclient" % "4.5.13",
+  "org.slf4j" % "slf4j-api" % "2.0.1"
 )
 
 // lazy val downloadSwaggerAndGenerateClient = taskKey[Unit]("Generating client from latest swagger.json")

--- a/src/main/java/net/avalara/avatax/rest/client/AvaTaxConstants.java
+++ b/src/main/java/net/avalara/avatax/rest/client/AvaTaxConstants.java
@@ -4,4 +4,5 @@ public class AvaTaxConstants {
     public static String Production_Url = "https://rest.avatax.com";
     public static String Sandbox_Url = "https://sandbox-rest.avatax.com";
     public static String XClientHeader = "X-Avalara-Client";
+    public static boolean shouldLogRequestAndResponse = false;
 }

--- a/src/main/java/net/avalara/avatax/rest/client/LogObject.java
+++ b/src/main/java/net/avalara/avatax/rest/client/LogObject.java
@@ -1,0 +1,90 @@
+package net.avalara.avatax.rest.client;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.util.EntityUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.TimeZone;
+
+public class LogObject {
+    private String httpMethod;
+    private String headerCorrelationId;
+    private String requestDetails;
+    private String responseDetails;
+    private URI requestURI;
+    private long totalExecutionTime;
+    private Integer statusCode;
+    private String timestamp;
+    private String exceptionMessage;
+    private String exceptionStackTrace;
+
+    private static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
+
+    static {
+        formatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+    }
+
+    public LogObject() {
+    }
+
+    public Integer getStatusCode() {
+        return statusCode;
+    }
+
+    public void populateRequestInfo(HttpRequestBase request) throws IOException {
+        this.timestamp = formatter.format(new Date());
+        this.httpMethod = request.getMethod();
+        this.requestURI = request.getURI();
+
+        if(AvaTaxConstants.shouldLogRequestAndResponse) {
+            if ("POST".equalsIgnoreCase(this.httpMethod)) {
+                this.requestDetails = EntityUtils.toString(((HttpPost) request).getEntity());
+            } else if ("PUT".equalsIgnoreCase(this.httpMethod)) {
+                this.requestDetails = EntityUtils.toString(((HttpPut)request).getEntity());
+            }
+        }
+    }
+
+    public void populateErrorInfo(String exceptionMessage, CloseableHttpResponse response,
+                                  long startTime, String errorStackTrace){
+        populateTotalExecutionTime(startTime);
+        populateStatusCode(response);
+        populateHeaderCorrelationId(response);
+        if(errorStackTrace != null) {
+            this.exceptionStackTrace = errorStackTrace;
+        }
+        this.exceptionMessage = exceptionMessage;
+    }
+
+    public void populateResponseInfo(CloseableHttpResponse response, String responseJson, long startTime) {
+        populateTotalExecutionTime(startTime);
+        populateStatusCode(response);
+        populateHeaderCorrelationId(response);
+        if(AvaTaxConstants.shouldLogRequestAndResponse) {
+            this.responseDetails = responseJson;
+        }
+    }
+
+    private void populateStatusCode(CloseableHttpResponse response) {
+        if(response != null && response.getStatusLine() != null)
+            this.statusCode = response.getStatusLine().getStatusCode();
+    }
+
+    private void populateTotalExecutionTime(long startTime) {
+        long stopTime = System.currentTimeMillis();
+        this.totalExecutionTime = stopTime - startTime;
+    }
+
+    private void populateHeaderCorrelationId(CloseableHttpResponse response) {
+        if(response != null && response.getHeaders("x-correlation-id") != null
+                && response.getHeaders("x-correlation-id").length > 0) {
+            this.headerCorrelationId = response.getHeaders("x-correlation-id")[0].getValue();
+        }
+    }
+}

--- a/src/main/java/net/avalara/avatax/rest/client/LogObject.java
+++ b/src/main/java/net/avalara/avatax/rest/client/LogObject.java
@@ -22,8 +22,6 @@ public class LogObject {
     private Integer statusCode;
     private String timestamp;
     private String exceptionMessage;
-    private String exceptionStackTrace;
-
     private static final SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss z");
 
     static {

--- a/src/main/java/net/avalara/avatax/rest/client/LogObject.java
+++ b/src/main/java/net/avalara/avatax/rest/client/LogObject.java
@@ -52,13 +52,10 @@ public class LogObject {
     }
 
     public void populateErrorInfo(String exceptionMessage, CloseableHttpResponse response,
-                                  long startTime, String errorStackTrace){
+                                  long startTime){
         populateTotalExecutionTime(startTime);
         populateStatusCode(response);
         populateHeaderCorrelationId(response);
-        if(errorStackTrace != null) {
-            this.exceptionStackTrace = errorStackTrace;
-        }
         this.exceptionMessage = exceptionMessage;
     }
 

--- a/src/main/java/net/avalara/avatax/rest/client/RestCall.java
+++ b/src/main/java/net/avalara/avatax/rest/client/RestCall.java
@@ -167,7 +167,7 @@ public class RestCall<T> implements Callable<T> {
             if (response.getStatusLine().getStatusCode() / 100 != 2)
             {
                 // populate error log info here
-                logObject.populateErrorInfo(json, response, startTime, null);
+                logObject.populateErrorInfo(json, response, startTime);
                 throw new AvaTaxClientException((ErrorResult) JsonSerializer.DeserializeObject(json, ErrorResult.class), model);
             }
             if (json != null) {
@@ -180,8 +180,7 @@ public class RestCall<T> implements Callable<T> {
             logObject.populateResponseInfo(response, json, startTime);
         } catch (JsonParseException jsonParseException) {
             // In case of exception, populate error log info here
-            StringWriter sw = getStringWriterForException(jsonParseException);
-            logObject.populateErrorInfo(jsonParseException.getMessage(), response, startTime, sw.toString());
+            logObject.populateErrorInfo(jsonParseException.getMessage(), response, startTime);
 
             ErrorResult errorResult = new ErrorResult();
             int statusCode = response.getStatusLine().getStatusCode();
@@ -199,8 +198,7 @@ public class RestCall<T> implements Callable<T> {
             errorResult.setError(errorInfo);
             throw new AvaTaxClientException(errorResult, model);
         } catch (Exception ex) {
-            StringWriter sw = getStringWriterForException(ex);
-            logObject.populateErrorInfo(ex.getMessage(), response, startTime, sw.toString());
+            logObject.populateErrorInfo(ex.getMessage(), response, startTime);
 
             throw ex;
         } finally {
@@ -209,12 +207,6 @@ public class RestCall<T> implements Callable<T> {
             response.close();
         }
         return obj;
-    }
-
-    private StringWriter getStringWriterForException(Exception ex) {
-        StringWriter sw = new StringWriter();
-        ex.printStackTrace(new PrintWriter(sw));
-        return sw;
     }
 
     private void logInfo(LogObject logObject) {

--- a/src/main/java/net/avalara/avatax/rest/client/RestCall.java
+++ b/src/main/java/net/avalara/avatax/rest/client/RestCall.java
@@ -1,7 +1,5 @@
 package net.avalara.avatax.rest.client;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
 import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 import net.avalara.avatax.rest.client.enums.ErrorTargetCode;
@@ -11,7 +9,6 @@ import net.avalara.avatax.rest.client.models.ErrorResult;
 import net.avalara.avatax.rest.client.serializer.JsonSerializer;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHost;
-import org.apache.http.HttpStatus;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.*;
 import org.apache.http.entity.ContentType;
@@ -24,7 +21,6 @@ import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
@@ -222,11 +218,10 @@ public class RestCall<T> implements Callable<T> {
     }
 
     private void logInfo(LogObject logObject) {
-        Gson gson = new GsonBuilder().setPrettyPrinting().disableHtmlEscaping().create();
         if(logObject.getStatusCode() != null && logObject.getStatusCode() < 400) {
-            logger.info(gson.toJson(logObject));
+            logger.info(JsonSerializer.SerializeObject(logObject));
         } else {
-            logger.error(gson.toJson(logObject));
+            logger.error(JsonSerializer.SerializeObject(logObject));
         }
     }
 


### PR DESCRIPTION
With this PR we are introducing the following changes:
- SLF4J The Simple Logging Facade for Java (SLF4J) serves as a simple facade or abstraction for various logging frameworks. This is enabled for Java SDK.
-  Client would implement the slf4j provider (or binding) on their end like Log4J, Logback etc to enable logging. 
- By default there is no logging enabled.
- All the attributes which are part of log message are in **LogObject.java**
- To enable or disable logging of request and response object, there is a boolean variable **"shouldLogRequestAndResponse"** in AvataxConstants. Default is set to **FALSE**
- Output of logging is in **JSON** format.