### PR TITLE
Update slf4j version

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,13 +89,13 @@ Following example shows how logging could be enabled on client side using Log4J.
 * In build.sbt or pom.xml we would add the following changes:
 ```java
 // build.sbt
-"org.slf4j" % "slf4j-log4j12" % "2.0.1"
+"org.slf4j" % "slf4j-log4j12" % "2.0.9"
 
 //pom.xml
 <dependency>
     <groupId>org.slf4j</groupId>
     <artifactId>slf4j-log4j12</artifactId>
-    <version>2.0.1</version>
+    <version>2.0.9</version>
 </dependency>
 ```
 * Make sure to refresh the project to get the latest dependencies

--- a/build.sbt
+++ b/build.sbt
@@ -6,9 +6,9 @@ version := "23.8.1"
 
 scalaVersion := "2.11.12"
 
-javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
-javacOptions in doc := Seq("-source", "1.7", "-Xdoclint:none")
+javacOptions in doc := Seq("-source", "1.8", "-Xdoclint:none")
 
 useGpg := true
 
@@ -57,7 +57,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "com.google.code.gson" % "gson" % "2.9.0",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",
-  "org.slf4j" % "slf4j-api" % "2.0.1"
+  "org.slf4j" % "slf4j-api" % "2.0.9"
 )
 
 // lazy val downloadSwaggerAndGenerateClient = taskKey[Unit]("Generating client from latest swagger.json")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-resolvers += "Sonatype snapshots" at "http://oss.sonatype.org/content/repositories/snapshots/"
+resolvers += "Sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/"
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.10")
 


### PR DESCRIPTION
slf4j-log4j12 v2.0.1 has multiple known vulnerabilities from dependencies and should be updated.

Also the documentation on https://developer.avalara.com/sdk/java/ needs to be updated as well. 