### PR TITLE
Fix NullPointerException when trying to close a non-existing response

### DIFF
--- a/src/main/java/net/avalara/avatax/rest/client/RestCall.java
+++ b/src/main/java/net/avalara/avatax/rest/client/RestCall.java
@@ -204,7 +204,10 @@ public class RestCall<T> implements Callable<T> {
         } finally {
             // Finally, log all the information related to request, response, error, etc
             logInfo(logObject);
-            response.close();
+
+            if (response != null) {
+                response.close();
+            }
         }
         return obj;
     }


### PR DESCRIPTION
**What**
When RestCall faces a timeout, a `NullPointerException` is thrown to the user.

**Expected Behavior**
The `SocketTimeoutException` is thrown to the user.

This PR adds a null check to the finally block, where the response is closed.