### PR TITLE
Don't depend on scala 2.11 for the main package.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,10 @@ version := "25.9.0"
 
 scalaVersion := "2.11.12"
 
+crossPaths := false
+
+autoScalaLibrary := false
+
 javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
 
 javacOptions in doc := Seq("-source", "1.7", "-Xdoclint:none")
@@ -54,6 +58,7 @@ pomExtra := (
 libraryDependencies ++= Seq(
   // Uncomment to use Akka
   //"com.typesafe.akka" % "akka-actor_2.11" % "2.3.9",
+  "org.scala-lang" % "scala-library" % scalaVersion.value % "test",
   "org.scalatest" %% "scalatest" % "3.0.8" % "test",
   "com.google.code.gson" % "gson" % "2.9.0",
   "org.apache.httpcomponents" % "httpclient" % "4.5.13",


### PR DESCRIPTION
Scala in used for tests only, this fix the dependencies and the artifact name.